### PR TITLE
fix: X20R5-NL ETH base config should populate Slot 1 only

### DIFF
--- a/purerackdiagram/config.yaml
+++ b/purerackdiagram/config.yaml
@@ -627,7 +627,7 @@ pci_config_lookup:
   - null
   - 4eth25roce
   - null
-  - 4eth25roce
+  - null
   - null
   fa-x20r5-fc:
   - null

--- a/ui/config.yaml
+++ b/ui/config.yaml
@@ -627,7 +627,7 @@ pci_config_lookup:
   - null
   - 4eth25roce
   - null
-  - 4eth25roce
+  - null
   - null
   fa-x20r5-fc:
   - null

--- a/update_config.py
+++ b/update_config.py
@@ -129,7 +129,7 @@ def static_global_config():
             # new X no Lom 
             "fa-x20r5-fc-nl": [None, "4eth25roce", None, "2fc", None],
             "fa-x50r5-fc-nl": [None, "4eth25roce",  None, "4fc", None],
-            "fa-x20r5-eth-nl": [None, "4eth25roce", None, "4eth25roce", None],
+            "fa-x20r5-eth-nl": [None, "4eth25roce", None, None, None],
             "fa-x50r5-eth-nl": [None, "4eth25roce" ,None, "4eth25roce", None],
 
              # New x R5 8/17 updated 4 port cards to be roce neabled.


### PR DESCRIPTION
## What

`fa-x20r5-eth-nl` populates PCIe Slot 1 **and** Slot 3 with a 4-port 10/25G card. The X20 R5-NL (ETH) base config ships a single 4-port 10/25G Ethernet card, in Slot 1 only.

Per the FlashArray//XR5 Port Usage and Definitions article, *Default Base Port Configuration - NL Chassis* — the card **moves** from Slot 3 to Slot 1 relative to a standard X20R5-ETH controller, it isn't duplicated. Only X50R5-NL and C50R5-NL (ETH) get two cards.

https://support.purestorage.com/r/flasharrayx/flasharray-xr5-port-usage-and-definitions

## Repro

```
?model=fa-x20r5&protocol=eth&face=back&chassis_gen=2&nl=TRUE&datapacksv2=((datapacks:((fm_size:2.2TB,fm_count:10))))&fm_label=TRUE&dp_label=TRUE
```

Before:

```
pci_config: [None, '4eth25roce', None, '4eth25roce', None]
ct0 slot ports: eth10 eth11 eth12 eth13 eth18 eth19 eth20 eth21
```

After:

```
pci_config: [None, '4eth25roce', None, None, None]
ct0 slot ports: eth10 eth11 eth12 eth13
```

Not just artwork — the extra card emitted four phantom ports per controller, so anything consuming the JSON port map for cabling or port planning saw 8 ports per array that don't exist.

## Cause

Looks like a copy-paste of the adjacent `fa-x50r5-eth-nl` entry in `update_config.py`, where the Slot 3 element was never cleared.

## Change

One line in `update_config.py`, then `python3 update_config.py` to regenerate. I confirmed the generator is byte-stable first — running it on an unmodified tree produces zero diff — so the only yaml churn is the intended change.

Checked the other five R5 NL entries and the standard X20R5 entries against the //XR5 and //CR5 articles. This is the only wrong one.

## Test coverage

There's no X20R5 NL case in the corpus — the two `nl-True` cases are both `fa-x50r5`, which this doesn't touch. That's how it survived. Happy to add a case if you want it in this PR.

Heads up on `test.py` / `test_compare.py`: I couldn't get a clean signal locally. The full run completes (2305 cases) but comparison against `test_validation.json` reports errors on cases this change can't affect, including FlashBlade ones — looks like Pillow/font drift against the `b2e2449` baseline on my machine rather than anything real. I verified the behavioural delta directly instead.
